### PR TITLE
замена jpegtran на mozjpeg

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -76,7 +76,7 @@ gulp.task(`images`, function () {
   return gulp.src(`source/img/**/*.{png,jpg,svg}`)
       .pipe(imagemin([
         imagemin.optipng({optimizationLevel: 3}),
-        imagemin.jpegtran({progressive: true}),
+        imagemin.mozjpeg({quality: 75, progressive: true}),
         imagemin.svgo({
             plugins: [
               {removeViewBox: false},


### PR DESCRIPTION
в соответствии с https://www.npmjs.com/package/gulp-imagemin